### PR TITLE
Common header for projects.

### DIFF
--- a/DLI_example0/DLI_example0.asx
+++ b/DLI_example0/DLI_example0.asx
@@ -7,6 +7,8 @@
 ; Public Domain
 ;
 
+		icl	'../common/mem_map.hea'
+
 		opt	h+				; Atari file headers on (dos binary format)
 		
 		org	$a000				; program/code will be located at this address
@@ -37,32 +39,32 @@ text		dta	d'   VECTORCON LABS   '
 
 st		ldx	<DL				; set the DL address
 		ldy	>DL
-		stx	$230
-		sty	$231
+		stx	DLIPTRS
+		sty	DLIPTRS+1
 		
 		lda	#$08				; set the default color (with DLI turned off)
-		sta	$2c4
+		sta	COLPF0S
 	
 		ldx	<dli0
 		ldy	>dli0				; set the DLI vector to the first DLI routine
-		stx	$200
-		sty	$201
+		stx	DLIPTRS
+		sty	DLIPTRS+1
 		
 ; here we have turn off the DLI when shift key is pressed		
 
-loop		lda	$14				; wait for VBL
-		cmp	$14
+loop		lda	RTCLOK+2				; wait for VBL
+		cmp	RTCLOK+2
 		beq	*-2
 
 		ldx	#$c0				; VBL + DLI
 		
-		lda	$d20f				; read the keys status
+		lda	SKSTAT				; read the keys status
 		and	#$08				; keep only the SHIFT key status
 		bne	no_shift
 		
 		ldx	#$40				; only VBL
 
-no_shift	stx	$d40e				; set the NMI status
+no_shift	stx	NMIEN				; set the NMI status
 
 		jmp	loop
 
@@ -73,12 +75,12 @@ no_shift	stx	$d40e				; set the NMI status
 dli0		pha					; store the A reg. on stack
 
 		lda	#$88				; set the colour in the hardware register
-		sta	$d016
+		sta	COLPF0
 		
 		lda	<dli1				; set the DLI vector to the next DLI routine
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli1
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A reg. from stack
 		rti
@@ -86,12 +88,12 @@ dli0		pha					; store the A reg. on stack
 dli1		pha					; store the A reg. on stack
 
 		lda	#$38				; set the colour in the hardware register
-		sta	$d016
+		sta	COLPF0
 		
 		lda	<dli2				; set the DLI vector to the next DLI routine
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli2
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A reg. from stack
 		rti
@@ -99,12 +101,12 @@ dli1		pha					; store the A reg. on stack
 dli2		pha					; store the A reg. on stack
 
 		lda	#$A8				; set the colour in the hardware register
-		sta	$d016
+		sta	COLPF0
 		
 		lda	<dli3				; set the DLI vector to the next DLI routine
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli3
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A reg. from stack
 		rti
@@ -112,12 +114,12 @@ dli2		pha					; store the A reg. on stack
 dli3		pha					; store the A reg. on stack
 
 		lda	#$58				; set the colour in the hardware register
-		sta	$d016
+		sta	COLPF0
 		
 		lda	<dli4				; set the DLI vector to the next DLI routine
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli4
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A reg. from stack
 		rti
@@ -129,20 +131,20 @@ dli4		pha					; store the A reg. on stack
 		
 
 ; and here we do a some simple raster-bar, using the loop-counter as a luminance value, 
-; and the $d40a (wsync) as a wait-for next line delay
+; and the WSYNC (wsync) as a wait-for next line delay
 
 
 		ldx	#$00				; X will be loop counter, and the value written to the color register
-d4l		stx	$d40a				; wait for h-sync
-		stx	$d016				; write X to the color register
+d4l		stx	WSYNC				; wait for h-sync
+		stx	COLPF0				; write X to the color register
 		inx					; increment loop counter
 		cpx	#$10				; end of loop? (compare X with $10)
 		bcc	d4l				; jump when carry clear (reg. X < $10)
 
 		lda	<dli0				; set the DLI vector to the first DLI routine
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli0
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore X reg. from stack
 		tax

--- a/DLI_example0/README.md
+++ b/DLI_example0/README.md
@@ -1,4 +1,4 @@
-This piece of code show how to use DLI interrupts in te- [x]t modes, to change the colour of te- [x]t and how the principles of the raster-bars works. This e- [x]ample is created after creating the e- [x]ample based on graphics modes, this code is shorter than previous and easier to understand.
+This piece of code show how to use DLI interrupts in text modes, to change the colour of text and how the principles of the raster-bars works. This example is created after creating the example based on graphics modes, this code is shorter than previous and easier to understand.
 
 
 TO DO:

--- a/DLI_example0/README.md
+++ b/DLI_example0/README.md
@@ -1,6 +1,6 @@
-This piece of code show how to use DLI interrupts in text modes, to change the colour of text and how the principles of the raster-bars works. This example is created after creating the example based on graphics modes, this code is shorter than previous and easier to understand.
+This piece of code show how to use DLI interrupts in te- [x]t modes, to change the colour of te- [x]t and how the principles of the raster-bars works. This e- [x]ample is created after creating the e- [x]ample based on graphics modes, this code is shorter than previous and easier to understand.
 
 
 TO DO:
 
-- change the addresses of registers to their names (sorry, but I remember the addresses of each hardware register directly, so I don't bother to remember their names).
+- [x] ~~change the addresses of registers to their names (sorry, but I remember the addresses of each hardware register directly, so I don't bother to remember their names)~~ mostly done by @skrzyp, needs review from @seban-slt.

--- a/DLI_example1/DLI_example1.asx
+++ b/DLI_example1/DLI_example1.asx
@@ -7,6 +7,8 @@
 ; Public Domain
 ;
 
+		inc	'../common/mem_map.hea'
+
 ; constants / defines
 
 alg4k		equ	$1000				; value used to algin to 4k boundary
@@ -42,7 +44,7 @@ dbg		org	*+1
 
 		opt	h+				; headers on
 
-		org	$2000				; program origin
+		org	DLIPTRS0				; program origin
 
 ; now a few words about screen memory organization... 
 ;
@@ -89,21 +91,21 @@ colt		dta	$84,$86,$88,$00,$00
 dli0		pha					; save A register on stack
 
 		lda	#chrom1+lum0			; set the chroma & luma for colpf0 register
-		sta	$d016
+		sta	COLPF0
 		lda	#chrom1+lum1			; set the chroma & luma for colpf1 register
-		sta	$d017
+		sta	COLPF1
 		lda	#chrom1+lum2			; set the chroma & luma for colpf2 register
-		sta	$d018
+		sta	COLPF2
 
 		lda	dbg				; check debug flag
 		bne	*+7
 		lda	#chrom1+$02			; if active change...
-		sta	$d01a				; the border colour
+		sta	COLBAK				; the border colour
 
 		lda	<dli1				; set vector for next DLI
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli1
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A register
 		rti					; return 
@@ -112,21 +114,21 @@ dli0		pha					; save A register on stack
 dli1		pha					; save A register on stack
 
 		lda	#chrom2+lum0			; set the chroma & luma for colpf0 register
-		sta	$d016
+		sta	COLPF0
 		lda	#chrom2+lum1			; set the chroma & luma for colpf1 register
-		sta	$d017
+		sta	COLPF1
 		lda	#chrom2+lum2			; set the chroma & luma for colpf2 register
-		sta	$d018
+		sta	COLPF2
 
 		lda	dbg				; check debug flag
 		bne	*+7
 		lda	#chrom2+$02			; if active change...
-		sta	$d01a				; the border colour
+		sta	COLBAK				; the border colour
 
 		lda	<dli2				; set vector for next DLI
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli2
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A register
 		rti					; return 
@@ -136,21 +138,21 @@ dli1		pha					; save A register on stack
 dli2		pha					; save A register on stack
 
 		lda	#chrom3+lum0			; set the chroma & luma for colpf0 register
-		sta	$d016
+		sta	COLPF0
 		lda	#chrom3+lum1			; set the chroma & luma for colpf1 register
-		sta	$d017
+		sta	COLPF1
 		lda	#chrom3+lum2			; set the chroma & luma for colpf2 register
-		sta	$d018
+		sta	COLPF2
 
 		lda	dbg				; check debug flag
 		bne	*+7
 		lda	#chrom3+$02			; if active change...
-		sta	$d01a				; the border colour
+		sta	COLBAK				; the border colour
 
 		lda	<dli3				; set vector for next DLI
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli3
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A register
 		rti					; return 
@@ -160,21 +162,21 @@ dli2		pha					; save A register on stack
 dli3		pha					; save A register on stack
 
 		lda	#chrom4+lum0a			; set the chroma & luma for colpf0 register
-		sta	$d016
+		sta	COLPF0
 		lda	#chrom4+lum1a			; set the chroma & luma for colpf1 register
-		sta	$d017
+		sta	COLPF1
 		lda	#chrom4+lum2a			; set the chroma & luma for colpf2 register
-		sta	$d018
+		sta	COLPF2
 
 		lda	dbg				; check debug flag
 		bne	*+7
 		lda	#chrom4+$02			; if active change...
-		sta	$d01a				; the border colour
+		sta	COLBAK				; the border colour
 
 		lda	<dli4				; set vector for next DLI
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli4
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A register
 		rti					; return 
@@ -185,21 +187,21 @@ dli3		pha					; save A register on stack
 dli4		pha					; save A register on stack
 
 		lda	#chrom5+lum0			; set the chroma & luma for colpf0 register
-		sta	$d016
+		sta	COLPF0
 		lda	#chrom5+lum1			; set the chroma & luma for colpf1 register
-		sta	$d017
+		sta	COLPF1
 		lda	#chrom5+lum2			; set the chroma & luma for colpf2 register
-		sta	$d018
+		sta	COLPF2
 
 		lda	dbg				; check debug flag
 		bne	*+7
 		lda	#chrom5+$02			; if active change...
-		sta	$d01a				; the border colour
+		sta	COLBAK				; the border colour
 
 		lda	<dli5				; set vector for next DLI
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli5
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A register
 		rti					; return 
@@ -209,21 +211,21 @@ dli4		pha					; save A register on stack
 dli5		pha					; save A register on stack
 
 		lda	#lum0a				; set the chroma & luma for colpf0 register
-		sta	$d016
+		sta	COLPF0
 		lda	#lum1a				; set the chroma & luma for colpf1 register
-		sta	$d017
+		sta	COLPF1
 		lda	#lum2a				; set the chroma & luma for colpf2 register
-		sta	$d018
+		sta	COLPF2
 
 		lda	dbg				; check debug flag
 		bne	*+7
 		lda	#$02				; if active change...
-		sta	$d01a				; the border colour
+		sta	COLBAK				; the border colour
 
 		lda	<dli0				; set vector for next DLI
-		sta	$200
+		sta	DLIPTRS
 		lda	>dli0
-		sta	$201
+		sta	DLIPTRS+1
 
 		pla					; restore A register
 		rti					; return 
@@ -233,8 +235,8 @@ dli5		pha					; save A register on stack
 ;
 ; wait for VBL sub-routine
 
-op		lda	$14				; wait for v-sync
-		cmp	$14
+op		lda	RTCLOK+2				; wait for v-sync
+		cmp	RTCLOK+2
 		beq	*-2
 		rts
 
@@ -244,13 +246,13 @@ op		lda	$14				; wait for v-sync
 ; code starts here
 
 st		lda	#$00				; turn off the screen
-		sta	$22f
+		sta	DMACTLS
 		jsr	op				; wait for VBL 
 
 		ldx	<dl				; set DL address
 		ldy	>dl	
-		stx	$230
-		sty	$231
+		stx	DLPTRS
+		sty	DLPTRS+1
 
 ; set the default colors for the first part of screen (color shadow registers are moved to hardware registers on sys VBL routine)
 
@@ -294,25 +296,25 @@ c0		lda	colt,x				; load palette value into A
 
 		ldx	<dli0				; set the DLI vector @ first DLI
 		ldy	>dli0
-		stx	$200
-		sty	$201
+		stx	DLIPTRS
+		sty	DLIPTRS+1
 		
 		lda	#$c0				; enable the VBL + DLI
-		sta	$d40e
+		sta	NMIEN
 
 		lda	#$22				; turn on the DMA and screen (normal size, 40 bytes per line)
-		sta	$22f
+		sta	DMACTLS
 
 loop		jsr	op				; wait for v-sync
 
-		lsr	$4d				; turn off the OS-attract mode
+		lsr	ATRACT				; turn off the OS-attract mode
 
-		lda	$d20f				; get the status...
+		lda	SKSTAT				; get the status...
 		and	#$08				; ...of SHIFT key
 		sta	dbg				; store it in debug flag (checked by DLI routines)
 		bne	*+7				; not set, jump!
 		lda	#chrom0				; change the...
-		sta	$d01a				; COLBACK register
+		sta	COLBAK				; COLBACK register
 
 ; let's do something hard (time consuming) to do for CPU...
 ;

--- a/DLI_example1/README.md
+++ b/DLI_example1/README.md
@@ -1,11 +1,14 @@
-This example show, the use of *Display List Interrupts* technique to achieve more colours on screen.
+This e- [x]ample show, the use of *Display List Interrupts* technique to achieve more colours on screen.
 
-The picture used in example is 160px * 240px and uses ANTIC $0E graphics mode (2 bit per pixel, 4 colours, 2:1 pixel proportion).
+The picture used in e- [x]ample is 160p- [x] * 240p- [x] and uses ANTIC $0E graphics mode (2 bit per pi- [x]el, 4 colours, 2:1 pi- [x]el proportion).
 
 The DLI is used to change the three play-field colour registers during each occurrence of DLI, this will allow to show more colours on screen.
 
-The example shows the "daisy chaining" of DLI routines, at end of each routine the DLI vector is changed to next DLI routine. So the next occurrence of Display List Interrupt will cause the execution of the new DLI routine.
+The e- [x]ample shows the "daisy chaining" of DLI routines, at end of each routine the DLI vector is changed to ne- [x]t DLI routine. So the ne- [x]t occurrence of Display List Interrupt will cause the e- [x]ecution of the new DLI routine.
 
 TO DO:
 
-- change the addresses of registers to their names (sorry, but I remember the addresses of each hardware register directly, so I don't bother to remember their names).
+- [x] ~~change the addresses of registers to their names (sorry, but I remember the addresse
+s of each hardware register directly, so I don't bother to remember their names)~~ mostly 
+done by @skrzyp, needs review from @seban-slt.
+

--- a/DLI_example1/README.md
+++ b/DLI_example1/README.md
@@ -1,14 +1,12 @@
-This e- [x]ample show, the use of *Display List Interrupts* technique to achieve more colours on screen.
+This example show, the use of *Display List Interrupts* technique to achieve more colours on screen.
 
-The picture used in e- [x]ample is 160p- [x] * 240p- [x] and uses ANTIC $0E graphics mode (2 bit per pi- [x]el, 4 colours, 2:1 pi- [x]el proportion).
+The picture used in example is 160px * 240px and uses ANTIC $0E graphics mode (2 bit per pixel, 4 colours, 2:1 pixel proportion).
 
 The DLI is used to change the three play-field colour registers during each occurrence of DLI, this will allow to show more colours on screen.
 
-The e- [x]ample shows the "daisy chaining" of DLI routines, at end of each routine the DLI vector is changed to ne- [x]t DLI routine. So the ne- [x]t occurrence of Display List Interrupt will cause the e- [x]ecution of the new DLI routine.
+The example shows the "daisy chaining" of DLI routines, at end of each routine the DLI vector is changed to next DLI routine. So the next occurrence of Display List Interrupt will cause the execution of the new DLI routine.
 
 TO DO:
 
-- [x] ~~change the addresses of registers to their names (sorry, but I remember the addresse
-s of each hardware register directly, so I don't bother to remember their names)~~ mostly 
-done by @skrzyp, needs review from @seban-slt.
+- [x] ~~change the addresses of registers to their names (sorry, but I remember the addresses of each hardware register directly, so I don't bother to remember their names)~~ mostly done by @skrzyp, needs review from @seban-slt.
 

--- a/PLOT_example/README.md
+++ b/PLOT_example/README.md
@@ -1,10 +1,8 @@
-This e- [x]ample shows how the PLOT function in hi-res monochromatic mode can be implemented.
+This example shows how the PLOT function in hi-res monochromatic mode can be implemented.
 
-Source contains two procedures... one is the slow version, but this shows the principles of operation. The second version is based on Lookup Tables, and show that using of LUT's can speed-up the code e- [x]ecution. Both implemented procedures arranged to run in controlled environment, and the number of plotted points in certain amount of time is calculated.
+Source contains two procedures... one is the slow version, but this shows the principles of operation. The second version is based on Lookup Tables, and show that using of LUT's can speed-up the code execution. Both implemented procedures arranged to run in controlled environment, and the number of plotted points in certain amount of time is calculated.
 
 TO DO:
 
-[- [x]] ~~change the addresses of registers to their names (sorry, but I remember the addresse
-s of each hardware register directly, so I don't bother to remember their names)~~ mostly 
-done by @skrzyp, needs review from @seban-slt.
+- [x] ~~change the addresses of registers to their names (sorry, but I remember the addresses of each hardware register directly, so I don't bother to remember their names)~~ mostly done by @skrzyp, needs review from @seban-slt.
 

--- a/PLOT_example/README.md
+++ b/PLOT_example/README.md
@@ -1,7 +1,10 @@
-This example shows how the PLOT function in hi-res monochromatic mode can be implemented.
+This e- [x]ample shows how the PLOT function in hi-res monochromatic mode can be implemented.
 
-Source contains two procedures... one is the slow version, but this shows the principles of operation. The second version is based on Lookup Tables, and show that using of LUT's can speed-up the code execution. Both implemented procedures arranged to run in controlled environment, and the number of plotted points in certain amount of time is calculated.
+Source contains two procedures... one is the slow version, but this shows the principles of operation. The second version is based on Lookup Tables, and show that using of LUT's can speed-up the code e- [x]ecution. Both implemented procedures arranged to run in controlled environment, and the number of plotted points in certain amount of time is calculated.
 
 TO DO:
 
-- change the addresses of registers to their names (sorry, but I remember the addresses of each hardware register directly, so I don't bother to remember their names).
+[- [x]] ~~change the addresses of registers to their names (sorry, but I remember the addresse
+s of each hardware register directly, so I don't bother to remember their names)~~ mostly 
+done by @skrzyp, needs review from @seban-slt.
+

--- a/PLOT_example/plot.asx
+++ b/PLOT_example/plot.asx
@@ -8,7 +8,7 @@
 ; Public Domain
 ;
 
-		inc	'../common/memory_map.hea'
+		inc	'../common/mem_map.hea'
 
 ; zero page variables
 

--- a/PLOT_example/plot.asx
+++ b/PLOT_example/plot.asx
@@ -8,6 +8,7 @@
 ; Public Domain
 ;
 
+		inc	'../common/memory_map.hea'
 
 ; zero page variables
 
@@ -44,20 +45,20 @@ st		jsr	make_dl		; create DL
 		
 		ldx	<dl		; set new DL
 		ldy	>dl
-		stx	$230
-		sty	$231
+		stx	DLPTRS
+		sty	DLPTRS+1
 
 		lda	#$00		; set colback
-		sta	$2c8
+		sta	COLBAKS
 		
 		lda	#$0a		; set pixel luminance
-		sta	$2c5
+		sta	COLPF1S
 		
 		lda	#$82		; set background color
-		sta	$2c6
+		sta	COLPF2S
 
 		lda	#$21		; screen size -> narrow (32 bytes, 256 hi-res pixels)
-		sta	$22f
+		sta	DMACTLS
 
 		jsr	op		; wait for VBL (shadow registers will be copied into hardware registers)
 
@@ -68,8 +69,8 @@ inf_loop	jsr	cls		; clear the screen
 		jsr	op		; wait for VBL
 
 		lda	#$00		; zero the A reg. :)
-		sta	$14		; clear RTCLOCK low-byte
-		sta	$13		; clear RTCLOCK mid-byte
+		sta	RTCLOK+2		; clear RTCLOCK low-byte
+		sta	RTCLOK+1		; clear RTCLOCK mid-byte
 		
 		sta	cnt1+0		; clear the pixel counter for slow-plot
 		sta	cnt1+1
@@ -77,11 +78,11 @@ inf_loop	jsr	cls		; clear the screen
 
 ; slow plot benchamark LOOP!
 
-splot_loop	lda	$d20a		; randomize Y pos.
+splot_loop	lda	RANDOM		; randomize Y pos.
 		and	#$7f		; keep the values below 128 (plot routine doesn't check the boundaries of Y position)
 		tay
 
-		ldx	$d20a		; randomize X pos. (0-255)
+		ldx	RANDOM		; randomize X pos. (0-255)
 		
 		jsr	plot		; do the PLOT!
 		
@@ -92,7 +93,7 @@ splot_loop	lda	$d20a		; randomize Y pos.
 		inc	cnt1+2
 cs0
 
-		lda	$13		; check the mid-byte od RTCLOCK
+		lda	RTCLOK+1		; check the mid-byte od RTCLOCK
 		beq	splot_loop	; loop when zero!
 
 		lda	cnt1+0		; convect cnt1 to dec
@@ -115,19 +116,19 @@ cs0
 		jsr	op		; wait for VBL
 
 		lda	#$00		; zero the A reg. :)
-		sta	$14		; clear RTCLOCK low-byte
-		sta	$13		; clear RTCLOCK mid-byte
+		sta	RTCLOK+2		; clear RTCLOCK low-byte
+		sta	RTCLOK+1		; clear RTCLOCK mid-byte
 		sta	cnt2+0		; clear the pixel counter for slow-plot
 		sta	cnt2+1
 		sta	cnt2+2
 
 ; fast plot benchamark LOOP!
 
-fplot_loop	lda	$d20a		; randomize Y pos.
+fplot_loop	lda	RANDOM		; randomize Y pos.
 		and	#$7f		; keep the values below 128 (plot routine doesn't check the boundaries of Y position)
 		tay
 
-		ldx	$d20a		; randomize X pos. (0-255)
+		ldx	RANDOM		; randomize X pos. (0-255)
 		
 		jsr	lut_plot	; do the PLOT!
 		
@@ -138,7 +139,7 @@ fplot_loop	lda	$d20a		; randomize Y pos.
 		inc	cnt2+2
 cs1
 
-		lda	$13		; check the mid-byte od RTCLOCK
+		lda	RTCLOK+1		; check the mid-byte od RTCLOCK
 		beq	fplot_loop	; loop when zero!
 
 		lda	cnt2+0		; convect cnt1 to dec
@@ -270,8 +271,8 @@ lut_plot	lda	adr_lo,y	; get screen address from LUT (based on Y position)
 ; wait for vblank
 ;
 
-op		lda	$14		; read the RTCLOCK low-byte
-		cmp	$14		; compare to itself (it will be inceremented on system VBI)
+op		lda	RTCLOK+2		; read the RTCLOCK low-byte
+		cmp	RTCLOK+2		; compare to itself (it will be inceremented on system VBI)
 		beq	*-2		; loop till equal!
 		rts
 

--- a/common/mem_map.hea
+++ b/common/mem_map.hea
@@ -36,6 +36,8 @@ DMACTLS = $022F ; SDMCTL
 DLPTRS  = $0230 ; SDLSTL
 ;         $0231 ; SDLSTH
 ;;;;;;; [real] ;;;;;;;;;;;;;
+VCOUNT  = $D40A ;        (R)
+WSYNC   = $D40A ;        (W)
 NMIEN   = $D40E ;        (W)
 
 ;;;;;;; POKEY ;;;;;;;;;;;;;;

--- a/common/mem_map.hea
+++ b/common/mem_map.hea
@@ -36,7 +36,6 @@ DMACTLS = $022F ; SDMCTL
 DLPTRS  = $0230 ; SDLSTL
 ;         $0231 ; SDLSTH
 ;;;;;;; [real] ;;;;;;;;;;;;;
-VCOUNT  = $D40A ;        (R)
 WSYNC   = $D40A ;        (W)
 NMIEN   = $D40E ;        (W)
 

--- a/common/mem_map.hea
+++ b/common/mem_map.hea
@@ -3,6 +3,12 @@
 ;  .:: :: ::.    (in XASM/MADS-like header format)
 ; .::' ::  '::.  © 2016 skrzyp
 
+; IMPORTANT NOTE
+; This memory man is (and will be) incomplete. 
+; It's meant to add required registers when needed to keep it simple,
+; because it's only used for educational purposes and not intended
+; to be used on production.
+
 ;;;;;;; ZEROPAGE ;;;;;;;;;;;
 RTCLOK  = $0012 ; 
 ;         $0013 ;

--- a/common/memory_map.hea
+++ b/common/memory_map.hea
@@ -1,0 +1,38 @@
+;   :: :: ::     MEM_MAP.HEA
+;   :: :: ::     Atari XL/XE memory map.
+;  .:: :: ::.    (in XASM/MADS-like header format)
+; .::' ::  '::.  © 2016 skrzyp
+
+;;;;;;; ZEROPAGE ;;;;;;;;;;;
+RTCLOK  = $0012 ; 
+;         $0013 ;
+;         $0014 ;
+ATRACT  = $004D ;
+
+;;;;;;; GTIA ;;;;;;;;;;;;;;;
+;;;;;;; [shadows] ;;;;;;;;;;
+COLPF0S = $02C4 ; COLOR0
+COLPF1S = $02C5 ; COLOR1
+COLPF2S = $02C6 ; COLOR2
+COLPF3S = $02C7 ; COLOR3
+COLBAKS = $02C8 ; COLOR4
+;;;;;;; [real] ;;;;;;;;;;;;;
+COLPF0  = $D016 ;        (W)
+COLPF1  = $D017 ;        (W)
+COLPF2  = $D018 ;        (W)
+COLBAK  = $D01A ; COLBK  (W)
+
+;;;;;;; ANTIC ;;;;;;;;;;;;;;
+;;;;;;; [shadows] ;;;;;;;;;;
+DLIPTRS = $0200 ; VDSLST
+;         $0201 ;
+DMACTLS = $022F ; SDMCTL
+DLPTRS  = $0230 ; SDLSTL
+;         $0231 ; SDLSTH
+;;;;;;; [real] ;;;;;;;;;;;;;
+NMIEN   = $D40E ;        (W)
+
+;;;;;;; POKEY ;;;;;;;;;;;;;;
+;;;;;;; [real] ;;;;;;;;;;;;;
+RANDOM  = $D20A ;        (R)
+SKSTAT  = $D20F ;        (R)


### PR DESCRIPTION
Replaces hardcoded hexadecimal addresses for known registers with commonly known symbolic names storead in header file (`common/mem_map.hea`).
